### PR TITLE
Added a URI.encode to catch URI::Parser Errors

### DIFF
--- a/libraries/esx_conn.rb
+++ b/libraries/esx_conn.rb
@@ -14,7 +14,7 @@ class ESXConnection
     end
 
     # Need to escape the string for chars that will cause URI::Parser to fail
-    connection_string_encoded = URI.encode(connection_string)
+    connection_string = URI.encode(connection_string)
 
     connection = URI(connection_string)
     if connection.scheme != 'vsphere' ||
@@ -30,6 +30,7 @@ class ESXConnection
       password: URI.decode(connection.password),
       insecure: true,
     }
+  end
 
   def connection
     return @conn if defined?(@conn)

--- a/libraries/esx_conn.rb
+++ b/libraries/esx_conn.rb
@@ -6,11 +6,15 @@ class ESXConnection
     require 'rbvmomi'
 
     # INSPEC_ESX_CONN='vsphere://root:vmwarevmware@192.168.10.139'
+    # Windows PowerShell $env:INSPEC_ESX_CONN = 'vsphere://domain\gbright:password@vCenter'
     connection_string = ENV['INSPEC_ESX_CONN']
     if connection_string.nil?
       puts 'Please use vsphere://username:password@host'
       return
     end
+
+    # Need to escape the string for chars that will cause URI::Parser to fail
+    connection_string_encoded = URI.encode(connection_string)
 
     connection = URI(connection_string)
     if connection.scheme != 'vsphere' ||
@@ -22,11 +26,10 @@ class ESXConnection
 
     @conn_opts = {
       host: connection.host,
-      user: connection.user,
-      password: connection.password,
+      user: URI.decode(connection.user),
+      password: URI.decode(connection.password),
       insecure: true,
     }
-  end
 
   def connection
     return @conn if defined?(@conn)


### PR DESCRIPTION
Kept hitting a URI::Parse error due to having a domain in my username and special characters in my password.

Added a URI.encode and decode to cater for that.

Signed-off-by: username-is-already-taken2 <digitialgaz@hotmail.com>